### PR TITLE
Fix language/terminology issues and add ChkTeX linting

### DIFF
--- a/.chktexrc
+++ b/.chktexrc
@@ -1,0 +1,13 @@
+CmdLine
+{
+  # Intentional macro-heavy dictionary formatting.
+  -n1
+
+  # Intentional Russian/list notation that confuses ChkTeX parsing.
+  -n9
+  -n10
+  -n17
+
+  # Intentional Russian/Babel shorthand punctuation, e.g. "--- and "--.
+  -n18
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install ChkTeX
+        run: sudo apt-get update && sudo apt-get install -y chktex
+
+      - name: Lint LaTeX
+        run: chktex -q -l .chktexrc cheatsheet.tex
+
       - name: Setup Pages
         uses: actions/configure-pages@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install ChkTeX
         run: sudo apt-get update && sudo apt-get install -y chktex
@@ -26,7 +26,7 @@ jobs:
         run: chktex -q -l .chktexrc cheatsheet.tex
 
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
 
       - name: Build
         uses: dante-ev/latex-action@2021-A
@@ -37,7 +37,7 @@ jobs:
         run: mkdir -p _site && mv *.pdf _site/
 
       - name: Upload artifacts
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   deploy:
     needs: build
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ The pre-built PDF document can be found [here](https://megabyde.github.io/math-r
 
 ## Acknowledgments
 
-This cheatsheet is based on the booklet distributed by Department of Foreign
-Languages in Moscow Institute of Physics and Technology.
+This cheatsheet is based on the booklet distributed by the Department of Foreign
+Languages at the Moscow Institute of Physics and Technology.

--- a/cheatsheet.tex
+++ b/cheatsheet.tex
@@ -78,14 +78,14 @@
           Such functions necessarily exist.
         }
 
-      \item Сравнительной степени прилагательного в роли определения должен; как правило,
+      \item Сравнительной степени прилагательного в роли определения должен, как правило,
         предшествовать неопределенный артикль.\\ [4pt]
         \textsf{
           Для решения задачи необходим более эффективный алгоритм.\\
-          For the problem to be solved a more effective algorithm is required.
+          For the problem to be solved, a more effective algorithm is required.
         }
 
-      \item Превосходной степени прилагательного в роли определения, должен предшествовать
+      \item Превосходной степени прилагательного в роли определения должен предшествовать
         определенный артикль.\\ [4pt]
         \textsf{
           Наиболее эффективная процедура была разработана в работе [1].\\
@@ -93,7 +93,7 @@
         }
 
       \item Обратите внимание на отсутствие артикля перед словом <<formula>>, за которым следует ее
-        номер. В данном случае слову <<formula>> было присвоено <<имя собственные>> "--- ее номер,
+        номер. В данном случае слову <<formula>> было присвоено <<имя собственное>> "--- ее номер,
         поэтому употребление артикля (определенного или неопределенного) избыточно. Сюда же
         относятся слова Section, Table, Figure (Fig.), Equation (Eq.) \etc\\ [4pt]
         \textsf{
@@ -103,14 +103,14 @@
 
       \item Никогда не ставьте артикль перед словом <<another>>. Ситуация со словом <<other>> "---
         более сложная: а) в значении <<какие-то другие>>, которое аналогично употреблению слова
-        <<another>>, определенный артикль перед, <<other>> никогда не ставится; б) в значении
+        <<another>>, определенный артикль перед <<other>> никогда не ставится; б) в значении
         <<другие (другой)>> (не тот, о котором речь шла выше), перед словом <<other>> всегда
         ставится определенный артикль, например: <<We had two pencils. I took one pencil, the other
         pencil is for you>>. <<The system comprises three equations. The first equation is similar
-        to Eq. (1.1), while, the other two equations reflect peculiarities of the physical system
-        being considered.\\ [4pt]
+        to Eq. (1.1), while the other two equations reflect peculiarities of the physical system
+        being considered>>.\\ [4pt]
         \textsf{
-          Другой случаи был рассмотрен в [1].\\
+          Другой случай был рассмотрен в [1].\\
           Another case has been considered in [1].
         }
 
@@ -128,7 +128,7 @@
       }
     \end{itemize}
 
-  \item Употребляйте слово <<rather>> в негативном контексте, в позитивном контекст употребляйте
+  \item Употребляйте слово <<rather>> в негативном контексте, в позитивном контексте употребляйте
     слово <<quite>>, например: <<The convergence of the series is rather bad>>, но <<The convergence
     of the series is quite good>>.
 
@@ -148,8 +148,8 @@
 
       \item <<at>> отвечает на вопрос <<в какой момент времени>>:\\ [4pt]
         \textsf{
-          At this, time moment a transition occurs from one state to another.\\
-          B этот момент времени происходит переход из одного состояния в другое.
+          At this time a transition occurs from one state to another.\\
+          В этот момент времени происходит переход из одного состояния в другое.
         }
 
       \item <<since>> отвечает на вопрос <<начиная с какого времени>> и всегда употребляется (в этом
@@ -173,7 +173,7 @@
           I will be back in five minutes.\\
           Я вернусь через пять минут.\\ [4pt]
         }
-        Обратите внимание, что то же самое можно сказать, используя оборот <<it will take \ldots do
+        Обратите внимание, что то же самое можно сказать, используя оборот <<it will take \ldots to do
         smth.>>, например, <<It will take an hour to compute the matrix>>.
 
       \item <<during>> отвечает на вопрос <<когда>> или <<во время чего>> и используется для
@@ -181,7 +181,7 @@
         \textsf{
           During the calculation of the matrix, other processors can compute the free term of the
           system.\\
-          Во время вычисления матрицы другие  процессоры могут вычислять свободный член системы.\\ [4pt]
+          Во время вычисления матрицы другие процессоры могут вычислять свободный член системы.\\ [4pt]
         }
         Распространенной ошибкой является употребление предлога <<during>> вместо предлога <<for>>.
 
@@ -195,7 +195,7 @@
         }
     \end{enumerate}
 
-  \item Оборот <<известно, что \ldots>> характерен, для русской научной лексики, в то  время как
+  \item Оборот <<известно, что \ldots>> характерен для русской научной лексики, в то время как
     оборот <<it is known that \ldots>>, который является дословным переводом, в английской научной
     лексике употребляется редко. Обычно в предложении, которое содержит данный оборот, содержится
     указание на то откуда известно, например, ссылка на работу. Если это так, то в переводе
@@ -206,28 +206,28 @@
     }
 
   \item Использование существительного в роли определения. Следует избегать употребления
-    существительного в роли определения, если основное слово  обозначает действие над данным
+    существительного в роли определения, если основное слово обозначает действие над данным
     существительным. Например, не следует переводить <<решение системы>> как <<the system
-    solution>>, правильный перевод <<the solution of system>>.\\ [4pt]
+    solution>>, правильный перевод <<the solution of the system>>.\\ [4pt]
     Избегайте слишком длинных (более трех определений) определительных рядов. Если без этого не
     удается обойтись "--- объединяйте члены определительного ряда, которые связаны друг с другом,
     при помощи дефиса, например <<linear-equation system>>.\\ [4pt]
     С другой стороны, не используйте <<of>>, если использование существительного в роли определения
     оправдано, например, <<the convergence rate>>, а~не <<the rate of convergence>> или <<the
     reaction temperature>>, а~не <<the tem\-perature of reaction>>.\\ [4pt]
-    He используйте существительное в роли определения, если за ним следуют слова или выражения,
+    Не используйте существительное в роли определения, если за ним следуют слова или выражения,
     которые по смыслу или грамматически связаны с~данным существительным, а не с определяемым
-    словом, например, фраза <<температура реакции, описанной в [1]>> должно переводиться как <<the
-    temperature of reaction described in [1], а не <<the reaction temperature described in [1]>>.
+    словом, например, фраза <<температура реакции, описанной в [1]>> должна переводиться как <<the
+    temperature of reaction described in [1]>>, а не <<the reaction temperature described in [1]>>.
 
   \item Никогда не используйте <<of>> после герундия перед прямым дополнением "--- это грубая
     грамматическая ошибка. Чтобы лучше запомнить это правило, можно провести следующую аналогию с
     русским языком: <<of>> в русском языке соответствует родительному падежу, в то же время прямое
-    дополнение) после деепричастия в русском языке всегда стоит в винительном падеже (а не в
+    дополнение после деепричастия в русском языке всегда стоит в винительном падеже (а не в
     родительном!) "--- <<делая кого, что>> $\rightarrow$ <<doing smth.>>, а не <<doing of smth.>>.
     Тем не менее, герундиальные формы глаголов часто используются в английском языке в качестве
     существительных (например, processing, testing \etal). Если такое употребление герундиальной
-    формы в языке устоялось, то, в  соответствии с обычными правилами, после него можно ставить
+    формы в языке устоялось, то, в соответствии с обычными правилами, после него можно ставить
     <<of>>, например, <<processing of experimental data>>.\\ [4pt]
     Никогда не используйте герундий в роли существительного, если существительное с тем же смыслом в
     языке уже существует, например: <<employment of this representation>>, а не <<employing of this
@@ -241,8 +241,8 @@
 
   \item Глаголы <<allow>>, <<permit>>, <<enable>> употребляются только в соответствии со следующими
     схемами:\\ [4pt] \textsf{
-      allow smb. to do smth.\\
-      allow smth. to be done\\
+      allow smb.\ to do smth.\\
+      allow smth.\ to be done\\
       allow smth.\\ [4pt]}
     Употребление <<allow to do smth.>> не допускается. Если возникают трудности с построением одной
     из конструкций, приведенных выше, всегда можно употребить безличное <<one>>, например:\\ [4pt]
@@ -263,7 +263,7 @@
       \end{tabular}
     \end{center}
     если за словом следует номер, например, <<Eq. (1)>>, но <<this equation>> (обратите внимание на
-    обязательный пробел после точки в сокращении). Если сокращаемое слово стоит и начале предложения,
+    обязательный пробел после точки в сокращении). Если сокращаемое слово стоит в начале предложения,
     то оно не сокращается, например:\\ [4pt]
     \textsf{
       This is easily seen from Eq. (1).\\ [4pt]
@@ -276,14 +276,14 @@
       \item В названиях теорем, равенств, неравенств \etc, образованных от имен собственных (фамилии
         ученых) придерживайтесь следующего правила: употребляйте притяжательный падеж, если перед
         словосочетанием нет артикля, и не употребляйте притяжательный падеж, если артикль
-        (определённый или неопределённый) имеется, например:\\ [4pt]
+        (определенный или неопределенный) имеется, например:\\ [4pt]
         \textsf{
           Cauchy's operator\\
           the Cauchy operator
         }
 
       \item Обороты, образованные по схеме <<прилаг. (или сущ.) + по + фамилия>> "--- например,
-        <<непрерывный по Липшицу>>, следует переводить как <<name + adjective (or noun.)>>,
+        <<непрерывный по Липшицу>>, следует переводить как <<name + adjective (or noun)>>,
         например, <<Lipschitz continuous>> или <<Lyapunov stability>> (<<устойчивость по
         Ляпунову>>).
     \end{enumerate}
@@ -295,7 +295,7 @@
         другим агентом, например:\\ [4pt]
         \textsf{Именно этот эффект обуславливает такое поведение системы.}\\ [4pt]
         В данном контексте данный оборот переводится следующим образом:\\ [4pt]
-        \textsf{It is this phenomenon that accounts for such a behavior of the system.}
+        \textsf{It is this phenomenon that accounts for such behavior of the system.}
 
       \item Для указания начала расшифровки предыдущего члена предложения. В данном контексте слово
         <<именно>> чаще всего употребляется вместе с союзом <<а>> "--- <<а именно>>, например:\\ [4pt]
@@ -310,11 +310,11 @@
         синонимом <<namely>>.
     \end{enumerate}
 
-  \item Согласование числа надлежащего и сказуемого.
+  \item Согласование числа подлежащего и сказуемого.
     \begin{enumerate}
       \item Помните имена существительные, которые формально имеют множественное число, но должны
-        употребляться со сказуемым в единственном числе, если речь идет о данных объектах, взятых и
-        совокупности, а не по-отдельности:
+        употребляться со сказуемым в единственном числе, если речь идет о данных объектах, взятых в
+        совокупности, а не по отдельности:
         \begin{center}
           \sffamily
           \begin{tabular}{lllll}
@@ -335,11 +335,11 @@
         в единственном числе, например:\\ [4pt]
         \textsf{
           To test the effect, 5 g of the substance was taken.\\ [4pt]
-          Ten meters or a copper wire  serves as a heat conductor.\\ [4pt]
+          Ten meters of copper wire serves as a heat conductor.\\ [4pt]
           Two years is needed to complete the experiments.
         }
 
-      \item Составное подлежащее, содержащее слова <<each>>, <<every>>, могут употребляться со
+      \item Составное подлежащее, содержащее слова <<each>>, <<every>>, может употребляться со
         сказуемым в единственном числе, например:\\ [4pt]
         \textsf{Every value of $n$ is to be tested separately.}
     \end{enumerate}
@@ -370,10 +370,10 @@
             multigrid      & а не & multi-grid\\
             nonpositive    & а не & non-positive\\
             antisymmetric  & а не & anti-symmetric\\
-            cooperation    & а не & cooperation
+            cooperation    & а не & co-operation
           \end{tabular}
         \end{center}
-        Ho: <<pre-Newtonian era>> или <<non-Gaussian distribution>>
+        Но: <<pre-Newtonian era>> или <<non-Gaussian distribution>>
 
       \item Не отделяйте дефисом суффикс <<like>>, если только это не приводит к~появлению тройной
         буквы <<l>>, например: <<chainlike>>, но <<ball-like>>.
@@ -386,7 +386,7 @@
       \item Используйте дефис для разделения префикса и химических названий, например:
         <<non-hydrogen>>.
 
-      \item Не используйте дефис, если первое из сокращаемых слов заканчивается на <<-lу>>, например
+      \item Не используйте дефис, если первое из сокращаемых слов заканчивается на <<-ly>>, например
         <<recently developed method>>.
 
       \item Используйте дефис для разделения числа и единицы измерения, если они используются в
@@ -399,7 +399,7 @@
 
       \item Используйте дефис для отделения таких модификаторов, как <<well>>, <<ever>>, <<still>>,
         например: <<well-known scientist>>, <<ever-present danger>>, <<still-new equipment>>. Однако,
-        дефис не используется, если данный модификатор  используется вместе с ещё одним модификатором,
+        дефис не используется, если данный модификатор используется вместе с еще одним модификатором,
         например: <<very well studied hypothesis>>.
 
       \item Не используйте дефис, если модификатор является собственным именем, например: <<Fourier
@@ -429,7 +429,7 @@
     \begin{enumerate}
       \item В перечислительных рядах, содержащих три и более членов ставьте запятую перед <<and>>
         или <<or>> (включая библиографию и заголовок), например <<Ivanov, Petrov, and Kuliev [3]
-        showed that \ldots>>, но  <<Smith and Venson [13] showed that \ldots>> или <<electrons,
+        showed that \ldots>>, но <<Smith and Venson [13] showed that \ldots>> или <<electrons,
         protons, and neutrons>>, но <<electrons and protons>>.
 
       \item Не ставьте запятую перед <<et al.>>, если ему предшествует только одна фамилия,
@@ -440,7 +440,7 @@
 
       \item Выделяйте запятыми придаточные предложения, которые вводятся словами <<which>>,
         <<where>> и <<who>>, например: <<The setup, which is shown in Fig. 1, is intended for
-        \ldots>>, <<The equation $f(x) = a_{11}\log N(e)$, where $a_{11}$ is а factor, can be solved
+        \ldots>>, <<The equation $f(x) = a_{11}\log N(e)$, where $a_{11}$ is a factor, can be solved
         numerically>>.
 
       \item Отделяйте запятой длинные вводные фразы, например: <<Because of an increasing amount of
@@ -448,18 +448,18 @@
         spectrum>>.
     \end{enumerate}
 
-  \item Перевод слова <<достаточно>> используемого в качестве модификатора.
+  \item Перевод слова <<достаточно>>, используемого в качестве модификатора.
     \begin{enumerate}
       \item Если словосочетание <<достаточно + полная форма прилагательного>> используется в
         качестве определения, то данный оборот следует переводить как <<sufficiently small +
         adjective>>, например, <<a sufficiently small value of the parameter>>.
 
       \item Конструкцию <<достаточно + краткая форма прилагательного>> следует переводить как в
-        следующем примере: <<If the value of this parameter is small enough equation (1) can be
+        следующем примере: <<If the value of this parameter is small enough, equation (1) can be
         rewritten as \ldots>>.
 
       \item Конструкции <<достаточно + краткая форма прилагательного + для того, чтобы>> следует
-        переводить как в следующем примере: <<If the value of $N$ is large enough to ensure, that
+        переводить как в следующем примере: <<If the value of $N$ is large enough to ensure that
         \ldots>>.
 
       \item Перевод существительных с модификаторами, указывающими их параметры. Обороты типа
@@ -512,7 +512,7 @@
 
   \item Не пишите <<don't>>, а пишите <<do not>> и т.\,п., \ie используйте полные формы.
 
-  \item Не путайте <<it's>> и <<its>>. <<It's>> "--- это краткая форма от <<it is>>, a <<its>> "---
+  \item Не путайте <<it's>> и <<its>>. <<It's>> "--- это краткая форма от <<it is>>, а <<its>> "---
     это <<его, ее>> по отношению к неодушевленным предметам.
 
   \item Не забывайте, что <<cannot>> пишется вместе.
@@ -545,19 +545,19 @@
   \textbf{\word е числа} proximate numbers;
 }
 \dictentry{быть в состоянии ч.-л. сделать} {to be able to do smth., to be capable of doing smth.;}
-\dictentry{быть готовым к ч.-л.}{to be ready for smth. (\cor doing smth.),
-  to be in a position to~do smth. (\eg Now we are in a position to formulate the final result);
+\dictentry{быть готовым к ч.-л.}{to be ready for smth.\ (\cor doing smth.),
+  to be in a position to~do smth.\ (\eg Now we are in a position to formulate the final result);
 }
 
 % ----------------------------------------------------------------------------------
 \dictchar{В}
 \dictentry{в дальнейшем} {in the sequel (\cor in the following);}
 \dictentry{включительно} {inclusive (\eg its $x$-derivatives up to the second order inclusive);}
-\dictentry{вложение} {imbedding, inclusion;\\
-  \textbf{\word\ в целом} global imbedding;\\
+\dictentry{вложение} {embedding, inclusion;\\
+  \textbf{\word\ в целом} global embedding;\\
   \textbf{отображение \word я} inclusion map;
 }
-\dictentry{вложенный} {imbedded;}
+\dictentry{вложенный} {embedded;}
 \dictentry{вне области} {in the exterior of the domain;}
 \dictentry{внутри области} {in the interior of the domain;}
 \dictentry{возникать} {arise;\\
@@ -602,20 +602,20 @@
 
 % ----------------------------------------------------------------------------------
 \dictchar{Д}
-\dictentry{давать} {yield, а не give (\eg Equation (5) yields ...);}
+\dictentry{давать} {yield, а не give (\eg Equation (5) yields \ldots);}
 \dictentry{делитель} {divisor;\\
   \textbf{наибольший общий \word} greatest common divisor;
 }
 \dictentry{диаметр} {diameter;\\
   \textbf{внешний \word} outside (а не outer) diameter, (o.d.);\\
-  \textbf{внутренний \word} inside (а не inner) diameter, (i.d);
+  \textbf{внутренний \word} inside (а не inner) diameter, (i.d.);
 }
 \dictentry{дифференцируемый} {differentiable;\\
   \textbf{дважды непрерывно \word} twice continuously differentiable;
   \textbf{\dot непрерывно \word\ $n$ раз} $n$ times differentiable;
   \textbf{\dot \word\ по $x$} $x$-differentiable (\cor differentiable
 with respect to $x$);
-  \textbf{\dot \word\ no Гато} G\^{a}teaux differentiable;
+  \textbf{\dot \word\ по Гато} G\^{a}teaux differentiable;
   \textbf{\dot слабо \word} weakly differentiable;
 }
 \dictentry{для этого} {to this end (\cor to do this);}
@@ -632,7 +632,7 @@ with respect to $x$);
 \dictentry{друг друга} {one another, а не each other;}
 \dictentry{достаточно (нар.)} {1) sufficiently (\eg For sufficiently small values of the parameter
   we have \ldots), 2) enough (\eg let $\varepsilon_\mu > 0$ be small enough to ensure that
-  $\Theta(\varepsilon) \in (0, T]$. The value of this function is small enough.), 3. rather, fairly,
+  $\Theta(\varepsilon) \in (0, T]$. The value of this function is small enough.), 3) rather, fairly,
   quite;\\
   \textbf{\dot \word\ показать, что \ldots} it is sufficient to show that \ldots (\cor it suffices
   to show that \ldots);
@@ -712,7 +712,7 @@ with respect to $x$);
   \textbf{\word\ Бохнера} Bochner integral;\\
   \textbf{\word\ Лебега} Lebesgue integral;\\
   \textbf{несобственный \word} improper integral;\\
-  \textbf{повторный \word} repeated integral;\\
+  \textbf{повторный \word} iterated integral;\\
   \textbf{\word\ по контуру} contour integral;\\
   \textbf{\word\ столкновений} collision integral;
 }
@@ -730,6 +730,7 @@ with respect to $x$);
 \dictentry{исчерпывать} {exhaust (\eg The numbers $\nu_1,\ldots,\nu_k$ exhaust the set of
   eigenvalues of matrix $A$.);
 }
+\dictentry{исчисление} {calculus (\eg operational calculus);}
 
 % ----------------------------------------------------------------------------------
 \dictchar{К}
@@ -766,12 +767,12 @@ with respect to $x$);
 }
 \dictentry{критерий} {criterion (\textit{pl.} criteria);\\
   \textbf{\dot \word\ существования} criterion for (а не of) the existence (\textit{or} criterion
-  for smth. to exist);
-  \textbf{\word\ компактности оператора Римана-Лиувилля} a criterion for the Riemann-Liouville
+  for smth.\ to exist);
+  \textbf{\word\ компактности оператора Римана"--~Лиувилля} a criterion for the Riemann"--~Liouville
   operator to be compact;\\
   \textbf{\word\ Арцелы} Arzel\`a criterion;\\
   \textbf{\word\ Дини} Dini criterion;\\
-  \textbf{\word\ Рица} Riesz criterion;
+  \textbf{\word\ Рисса} Riesz criterion;
 }
 \dictentry{кусочно-гладкая (-непрерывная, -постоянная \etc)} {piecewise-smooth (-continuous,
   -constant, etc.);
@@ -804,8 +805,8 @@ with respect to $x$);
   \textbf{\word\ жесткости} stiffness matrix;\\
   \textbf{кососимметричная \word} skew-symmetric matrix;\\
   \textbf{плохо обусловленная \word} ill-conditioned matrix;\\
-  \textbf{нижняя треугольная \word} lower-triangular matrix;\\
-  \textbf{разреженная \word} sparse matrix, inflated matrix;\\
+  \textbf{нижняя треугольная \word} lower triangular matrix;\\
+  \textbf{разреженная \word} sparse matrix;\\
   \textbf{самосопряженная \word} self-adjoint matrix;\\
   \textbf{треугольная \word} triangular matrix;\\
   \textbf{хорошо обусловленная \word} well-conditioned matrix;
@@ -837,9 +838,9 @@ with respect to $x$);
 \newpage
 % ----------------------------------------------------------------------------------
 \dictchar{Н}
-\dictentry{на всем пространстве $H$} {on the whole of the space $H$;}
+\dictentry{на всём пространстве $H$} {on the whole of the space $H$;}
 \dictentry{накладывать требования на \ldots} {impose requirements on \ldots;}
-\dictentry{напоминать} {remind а не recall;}
+\dictentry{напоминать} {remind, а не recall;}
 \dictentry{не более} {not more than, at most (\eg the equation has at most three distinct roots);}
 \dictentry{не менее} {not fewer than (with countable nouns), at least;}
 \dictentry{невырожденный (оператор, матрица)} {nonsingular;}
@@ -863,21 +864,21 @@ with respect to $x$);
 \dictentry{непрерывный} {continuous;\\
   \textbf{\dot \word\ слева (справа)} continuous to the left (right) (\textit{or} left (right)
   continuous);
-  \textbf{\dot \word\ по Липшицу} Lipschits continuous;
+  \textbf{\dot \word\ по Липшицу} Lipschitz continuous;
 }
 \dictentry{неприводимый} {irreducible;}
 \dictentry{непустой} {nonempty;}
 \dictentry{неравенство} {inequality;\\
-  \textbf{\word\ Гардинга} Garding inequality;\\
-  \textbf{двустороннее \word} double-sided inequality;\\
-  \textbf{\word\ Коши"--~Буняковского} Schwarz inequality;\\
-  \textbf{\word\ Минковского} Minkovski inequality;\\
+  \textbf{\word\ Гардинга} G\r{a}rding inequality;\\
+  \textbf{двустороннее \word} two-sided inequality;\\
+  \textbf{\word\ Коши"--~Буняковского} Cauchy"--~Schwarz inequality;\\
+  \textbf{\word\ Минковского} Minkowski inequality;\\
   \textbf{одностороннее \word} one-sided inequality;\\
   \textbf{строгое \word} strict inequality;\\
   \textbf{\word\ Юнга} Young inequality;
 }
 \dictentry{несколько слабее (сильнее \etc)} {somewhat weaker (stronger and so on);}
-\dictentry{не является гладкой функцией от $t$} {fails to be smooth function of $t$;}
+\dictentry{не является гладкой функцией от $t$} {fails to be a smooth function of $t$;}
 \dictentry{ноль} {zero, null;\\
   \textbf{\dot нули функции} zeros (а не zeroes) of the function;
 }
@@ -898,7 +899,7 @@ with respect to $x$);
 \dictentry{обозначать} {denote;}
 \dictentry{обозначение} {notation, а не notations;}
 \dictentry{оболочка} {span (\eg the real linear span of the functions);}
-\dictentry{образованы \ldots} { are formed of (а не from) \ldots;}
+\dictentry{образованы \ldots} {are formed of (а не from) \ldots;}
 \dictentry{обратимость (матрицы)} {invertibility;}
 \dictentry{обратимый} {invertible;}
 \dictentry{обратный} {contrary (\textit{see} если не оговорено противное, задача, утверждение);\\
@@ -917,7 +918,7 @@ with respect to $x$);
   \textbf{\dot \word\ снизу} bounded below;
   \textbf{\dot не\word} unbounded;
 }
-\dictentry{однозначный} {single valued;}
+\dictentry{однозначный} {single-valued;}
 \dictentry{однозначно определять} {to determine uniquely;}
 \dictentry{однолистный} {one-sheeted;}
 \dictentry{однородно по $t$} {uniformly with respect to $t$ (\textit{or} uniformly in $t$);}
@@ -931,7 +932,7 @@ with respect to $x$);
 \dictentry{оператор} {operator;\\
   \textbf{\word\ определенный на пространстве $L_{p_1}$ и действующий в $L_2$} operator defined on
   the space $L_{p_1}$ and acting on $L_2$;\\
-  \textbf{\word\ Лапласа"--~Белтрами} Laplace"--~Beltrami equation;\\
+  \textbf{\word\ Лапласа"--~Белтрами} Laplace"--~Beltrami operator;\\
   \textbf{\word\ Пуанкаре} Poincar\'e operator;\\
   \textbf{\word\ Римана"--~Лиувилля} Riemann"--~Liouville operator;\\
   \textbf{\word\ свертки} convolution operator;
@@ -974,8 +975,8 @@ with respect to $x$);
 }
 \dictentry{подчеркивать} {stress, emphasize;}
 \dictentry{позволять} {allow, enable, permit, make it possible;\\
-  allow (permit, enable) smb. to do smth.;\\
-  allow smth. to be done;\\
+  allow (permit, enable) smb.\ to do smth.;\\
+  allow smth.\ to be done;\\
   Definition 1 makes it possible to compare the times when the level $R$ is reached.;
 }
 \dictentry{по крайней мере} {at least;\\
@@ -1021,7 +1022,7 @@ with respect to $x$);
   \textbf{сильный \word\ максимума} strong maximum principle;
 }
 \dictentry{приравнивать} {equate;\\
-  \textbf{\dot \word\ коэффициенты при \ldots} equate the coefficients at \ldots;
+  \textbf{\dot \word\ коэффициенты при \ldots} equate the coefficients of \ldots;
 }
 \dictentry{приходить к} {arrive at, а не to;}
 \dictentry{проверка результатов (факта)} {verification of the results;}
@@ -1037,11 +1038,11 @@ with respect to $x$);
   \textbf{\dot \word\ по времени} time derivative;\\
   \textbf{обыкновенная \word} ordinary derivative;\\
   \textbf{старшая \word} leading derivative;\\
-  \textbf{\word\ Фреше} Frechet derivative;\\
+  \textbf{\word\ Фреше} Fr\'echet derivative;\\
   \textbf{частная \word} partial derivative;
 }
 \dictentry{промежуток} {range;\\
-  \textbf{\word\ интегрирования} integration range:
+  \textbf{\word\ интегрирования} integration range;
 }
 \dictentry{пространство} {space;\\
   \textbf{\dot \word\ над числовым полем} space over the number field;\\
@@ -1057,7 +1058,7 @@ with respect to $x$);
 \dictentry{размерность} {dimension, а не dimensionality;}
 \dictentry{разрешимость} {solvability;}
 \dictentry{разрыв} {discontinuity;\\
-  \textbf{\word\ первого рода} first-kind discontinuity;
+  \textbf{\word\ первого рода} discontinuity of the first kind;
 }
 \dictentry{раскладывать} {expand;\\
   \textbf{\word\ по степеням малого параметра} expand in powers of small parameter;
@@ -1072,7 +1073,7 @@ with respect to $x$);
 }
 \dictentry{резюмировать} {summarize;}
 \dictentry{рекуррентный} {recurrent;}
-\dictentry{pекуррентно} {recurrently;\\
+\dictentry{рекуррентно} {recurrently;\\
   \textbf{\dot определять \word} define recurrently;
 }
 \dictentry{решение} {solution;\\
@@ -1153,7 +1154,6 @@ with respect to $x$);
 \dictentry{с учетом \ldots} {with \ldots taken into account (\eg the set of eigenvalues with
   multiplicity taken into account);
 }
-\dictentry{счисление} {calculus (\eg operational calculus);}
 
 % ----------------------------------------------------------------------------------
 \dictchar{Т}
@@ -1167,14 +1167,14 @@ with respect to $x$);
   \textbf{\word\ Биркхофа} Birkhoff theorem;\\
   \textbf{\word\ единственности} uniqueness theorem;\\
   \textbf{калибровочная \word} calibration theorem;\\
-  \textbf{\word\ Леви"--~Деспланка} Levy"--~Desplank theorem;\\
+  \textbf{\word\ Леви"--~Деспланка} L\'evy"--~Desplanques theorem;\\
   \textbf{\word\ Парсеваля} Parseval theorem;\\
   \textbf{\word\ Планчереля} Plancherel theorem;\\
   \textbf{\word\ сравнения} comparison theorem;\\
   \textbf{\word\ существования и единственности} existence and uniqueness theorem;\\
   \textbf{\word\ существования} existence theorem;\\
-  \textbf{\word\ Фубини} Fubini's theorem;\\
-  \textbf{\word\ Шоде о неподвижной точке} Schauder fixed-point theorem;
+  \textbf{\word\ Фубини} Fubini theorem;\\
+  \textbf{\word\ Шаудера о неподвижной точке} Schauder fixed-point theorem;
 }
 \dictentry{точка} {point;\\
   \textbf{несобственная \word} ideal point;\\
@@ -1187,7 +1187,7 @@ with respect to $x$);
 }
 \dictentry{точный} {exact;}
 \dictentry{то, что они малы, показывается на примере уравнения (1)} {that they are small is shown by
-  the example of Eq. (1).;
+  the example of Eq. (1);
 }
 \dictentry{тройка} {triple;}
 
@@ -1209,8 +1209,8 @@ with respect to $x$);
   \textbf{Диофантово \word} Diophantine equation;\\
   \textbf{дифференциальные \word я Фукса} Fuchsian differential equations;\\
   \textbf{интегральное \word} integral equation;\\
-  \textbf{\word\ Ито} Ito equation;\\
-  \textbf{\word\ Кортевега-де Фриза} Korteweg-de Vries equation;\\
+  \textbf{\word\ Ито} It\^o equation;\\
+  \textbf{\word\ Кортевега"--~де Фриза} Korteweg"--~de Vries equation;\\
   \textbf{\word я Навье"--~Стокса} Navier"--~Stokes equations;\\
   \textbf{обыкновенное дифференциальное \word} ordinary differential equation;\\
   \textbf{\word\ Ора"--~Зоммерфельда} Orr"--~Sommerfeld equation;\\
@@ -1252,15 +1252,15 @@ with respect to $x$);
   \textbf{сеточная \word} mesh function;\\
   \textbf{\word\ с ограниченной вариацией} a function of bounded variation;\\
   \textbf{\word\ Тичмарша} Titchmarsh function;\\
-  \textbf{\word\ Тичмарша"--~Вейла} Titchmarsh-Weyl function;\\
+  \textbf{\word\ Тичмарша"--~Вейла} Titchmarsh"--~Weyl function;\\
   \textbf{\word\ Ханкеля} Hankel function;\\
-  \textbf{\word\ Хэвисайда} Heaviside unit function;
+  \textbf{\word\ Хэвисайда} Heaviside step function;
 }
 
 % ----------------------------------------------------------------------------------
 \dictchar{Ц}
 \dictentry{цепь} {chain;\\
-  \textbf{вложенная \word\ Маркова} imbedded Markov chain;
+  \textbf{вложенная \word\ Маркова} embedded Markov chain;
 }
 
 % ----------------------------------------------------------------------------------
@@ -1274,14 +1274,14 @@ with respect to $x$);
   \textbf{целая \word} integral part (\cor the greatest integer in);
 }
 \dictentry{через} {in terms of, through, via;\\
-  \textbf{\dot выражать через \ldots}  express in terms of \ldots;
+  \textbf{\dot выражать через \ldots} express in terms of \ldots;
 }
 \dictentry{черта} {bar;\\
-  \textbf{\dot Черта над буквой обозначает комплексно"=сопряжённую величину.}
-  The bar over a letter indicates a complex conjugate.;
+  \textbf{\dot Черта над буквой обозначает комплексно"=сопряженную величину.}
+  The bar over a letter indicates a complex conjugate;
 }
 \dictentry{число} {number;\\
-  \textbf{число обусловленности} conditioning number;
+  \textbf{число обусловленности} condition number;
 }
 
 % ----------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Language, terminology, and punctuation corrections across the cheatsheet, plus a ChkTeX lint step in CI.

### `cheatsheet.tex`
- **Russian/English typos & grammar**: `и начале → в начале`; missing article in `the solution of the system`; de-calqued `equate the coefficients at → of`.
- **Math terminology**: `счисление → исчисление` (calculus; entry moved to the correct alphabetical section); dropped the bogus `inflated matrix` synonym for `разреженная матрица` (sparse matrix); `Heaviside unit → step function`; `Schwarz → Cauchy–Schwarz`.
- **Proper names** (verified against Wikipedia / Большая российская энциклопедия): `Шоде → Шаудера` (Schauder); `Рица → Рисса` (Riesz); consistent two-surname en-dashes for Riemann–Liouville, Korteweg–de Vries, Titchmarsh–Weyl.
- **Style/consistency**: `Fubini's → Fubini`; `lower-triangular → lower triangular`; `imbedding/imbedded → embedding/embedded`.
- **ё policy**: restored ё only where it carries information — `Гёльдера` (Hölder, proper name) and `на всём пространстве` (все/всё disambiguation); left е elsewhere for consistency.

### CI
- `.github/workflows/main.yml`: new ChkTeX lint step.
- `.chktexrc`: lint configuration consumed by that step.

### README
- Article-usage fix in the acknowledgments.

## Verification
- `latexmk` builds clean.
- `chktex -q -l .chktexrc cheatsheet.tex` passes (no warnings).

## Open question
`Рица → Рисса` assumes the intended name is **Riesz** (the only reading yielding a real object — the Riesz–Kolmogorov compactness criterion). If the source booklet meant **Ritz**, this should instead be `Ритца` and the English reworked. One-line follow-up either way.